### PR TITLE
Update the nextflow_schema and input_schema

### DIFF
--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,4 +1,4 @@
-sample,sample_name,mikrokondo_data,predicted_identification_name,QC_status_overall
+sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
 SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASS
 SAMPLE2,EC002,,Escherichia coli,PASS
 SAMPLE3,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASS

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -40,6 +40,6 @@
                 "pattern": "^[^\\n\\t\"]+$"
             }
         },
-        "required": ["sample"]
+        "required": ["sample", "predicted_identification_name", "qc_status_overall"]
     }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -29,6 +29,22 @@
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
                     "fa_icon": "fas fa-folder-open"
                 },
+                "email": {
+                    "type": "string",
+                    "description": "Email address for completion summary.",
+                    "fa_icon": "fas fa-envelope",
+                    "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
+                    "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$"
+                }
+            }
+        },
+        "sistr_reportable_file": {
+            "title": "SISTR reportable file",
+            "type": "object",
+            "fa_icon": "fas fa-terminal",
+            "default": "",
+            "description": "File listing the reportable serovars that can be identified by SISTR.",
+            "properties": {
                 "reportable_serovars": {
                     "type": "string",
                     "format": "file-path",
@@ -37,13 +53,6 @@
                     "description": "Path to file containing reportable Salomonella serovars",
                     "help_txt": "This file contains the list of validated and reportable Salmonella serovars for QC validation",
                     "fa_icon": "fas fa-file-csv"
-                },
-                "email": {
-                    "type": "string",
-                    "description": "Email address for completion summary.",
-                    "fa_icon": "fas fa-envelope",
-                    "help_text": "Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits. If set in your user config file (`~/.nextflow/config`) then you don't need to specify this on the command line for every run.",
-                    "pattern": "^([a-zA-Z0-9_\\-\\.]+)@([a-zA-Z0-9_\\-\\.]+)\\.([a-zA-Z]{2,5})$"
                 }
             }
         },
@@ -204,6 +213,10 @@
     "allOf": [
         {
             "$ref": "#/definitions/input_output_options"
+        },
+
+        {
+            "$ref": "#/definitions/sistr_reportable_file"
         },
         {
             "$ref": "#/definitions/institutional_config_options"

--- a/tests/data/samplesheets/samplesheet1.csv
+++ b/tests/data/samplesheets/samplesheet1.csv
@@ -1,4 +1,4 @@
-sample,sample_name,mikrokondo_data,predicted_identification_name,QC_status_overall
+sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
 SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASS
 SAMPLE2,EC002,,Escherichia coli,PASS
 SAMPLE3,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASS

--- a/tests/data/samplesheets/samplesheet_ectyper.csv
+++ b/tests/data/samplesheets/samplesheet_ectyper.csv
@@ -1,4 +1,4 @@
-sample,sample_name,mikrokondo_data,predicted_identification_name,QC_status_overall
+sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
 SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASS
 SAMPLE2,EC002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC002.flat_sample.json.gz,Escherichia coli,PASS
 SAMPLE3,EC004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC004.flat_sample.json.gz,Escherichia coli,FAIL

--- a/tests/data/samplesheets/samplesheet_exclusions.csv
+++ b/tests/data/samplesheets/samplesheet_exclusions.csv
@@ -1,4 +1,4 @@
-sample,sample_name,mikrokondo_data,predicted_identification_name,QC_status_overall
+sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
 SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASS
 SAMPLE2,SALM004,,Salmonella enterica,PASS
 SAMPLE3,SALM005,,Salmonella enterica,FAIL

--- a/tests/data/samplesheets/samplesheet_incorrectJSON.csv
+++ b/tests/data/samplesheets/samplesheet_incorrectJSON.csv
@@ -1,2 +1,2 @@
-sample,sample_name,mikrokondo_data,predicted_identification_name,QC_status_overall
+sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
 SAMPLE1,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASS

--- a/tests/data/samplesheets/samplesheet_sequence.csv
+++ b/tests/data/samplesheets/samplesheet_sequence.csv
@@ -1,4 +1,4 @@
-sample,sample_name,mikrokondo_data,predicted_identification_name,QC_status_overall
+sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
 SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASS
 SAMPLE2,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM002.flat_sample.json.gz,Salmonella_enterica,FAIL
 SAMPLE4,SALM005,,Salmonella_enterica,PASS

--- a/tests/data/samplesheets/samplesheet_sistr.csv
+++ b/tests/data/samplesheets/samplesheet_sistr.csv
@@ -1,4 +1,4 @@
-sample,sample_name,mikrokondo_data,predicted_identification_name,QC_status_overall
+sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
 SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASS
 SAMPLE2,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM002.flat_sample.json.gz,Salmonella_enterica,FAIL
 SAMPLE3,SALM005,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM005.flat_sample.json.gz,Salmonella_enterica,PASS


### PR DESCRIPTION
This PR updates the `nextflow_schema.json` to move the required file `reportable_serovars` to its own definition section. Previously it had been in the `input/output` section and the pipeline was trying to render thus as a table of samples. 

Additionally, this PR updates the `input_schema.json` to have all inputs in lower case to avoid any possible confusion in IRIDA Next. The test data samplesheets were also updated. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
