### PR TITLE
Update workflow and required files related to IRIDA Next

### DIFF
--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,8 +1,8 @@
 sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
-SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASS
-SAMPLE2,EC002,,Escherichia coli,PASS
-SAMPLE3,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASS
-SAMPLE4,SALM004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM004.flat_sample.json.gz,Salmonella enterica,PASS
-SAMPLE5,SALM003,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM003.flat_sample.json.gz,Salmonella enterica,FAIL
-SAMPLE6,LIST001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/LIST001.flat_sample.json.gz,Listeria monocytogenes,PASS
-SAMPLE7,LIST001,,Listeria monocytogenes,PASS
+SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASSED
+SAMPLE2,EC002,,Escherichia coli,PASSED
+SAMPLE3,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASSED
+SAMPLE4,SALM004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM004.flat_sample.json.gz,Salmonella enterica,PASSED
+SAMPLE5,SALM003,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM003.flat_sample.json.gz,Salmonella enterica,FAILED
+SAMPLE6,LIST001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/LIST001.flat_sample.json.gz,Listeria monocytogenes,PASSED
+SAMPLE7,LIST001,,Listeria monocytogenes,PASSED

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -40,6 +40,6 @@
                 "pattern": "^[^\\n\\t\"]+$"
             }
         },
-        "required": ["sample", "predicted_identification_name", "qc_status_overall"]
+        "required": ["sample", "mikrokondo_data", "predicted_identification_name", "qc_status_overall"]
     }
 }

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -40,6 +40,6 @@
                 "pattern": "^[^\\n\\t\"]+$"
             }
         },
-        "required": ["sample", "mikrokondo_data", "predicted_identification_name", "qc_status_overall"]
+        "required": ["sample", "predicted_identification_name", "qc_status_overall"]
     }
 }

--- a/tests/data/samplesheets/samplesheet1.csv
+++ b/tests/data/samplesheets/samplesheet1.csv
@@ -1,8 +1,8 @@
 sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
-SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASS
-SAMPLE2,EC002,,Escherichia coli,PASS
-SAMPLE3,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASS
-SAMPLE4,SALM004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM004.flat_sample.json.gz,Salmonella enterica,PASS
-SAMPLE5,SALM003,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM003.flat_sample.json.gz,Salmonella enterica,FAIL
-SAMPLE6,LIST001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/LIST001.flat_sample.json.gz,Listeria monocytogenes,PASS
-SAMPLE7,LIST001,,Listeria monocytogenes,PASS
+SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASSED
+SAMPLE2,EC002,,Escherichia coli,PASSED
+SAMPLE3,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASSED
+SAMPLE4,SALM004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM004.flat_sample.json.gz,Salmonella enterica,PASSED
+SAMPLE5,SALM003,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM003.flat_sample.json.gz,Salmonella enterica,FAILED
+SAMPLE6,LIST001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/LIST001.flat_sample.json.gz,Listeria monocytogenes,PASSED
+SAMPLE7,LIST001,,Listeria monocytogenes,PASSED

--- a/tests/data/samplesheets/samplesheet_ectyper.csv
+++ b/tests/data/samplesheets/samplesheet_ectyper.csv
@@ -1,9 +1,9 @@
 sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
-SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASS
-SAMPLE2,EC002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC002.flat_sample.json.gz,Escherichia coli,PASS
-SAMPLE3,EC004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC004.flat_sample.json.gz,Escherichia coli,FAIL
-SAMPLE4,EC005,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC005.flat_sample.json.gz,Escherichia coli,PASS
-SAMPLE5,EC006,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC006.flat_sample.json.gz,Escherichia coli,PASS
-SAMPLE6,EC007,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC007.flat_sample.json.gz,Escherichia coli,PASS
-SAMPLE7,EC008,,Escherichia coli,PASS
-SAMPLE8,EA001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EA001.flat_sample.json.gz,Escherichia coli,PASS
+SAMPLE1,EC001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC001.flat_sample.json.gz,Escherichia coli,PASSED
+SAMPLE2,EC002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC002.flat_sample.json.gz,Escherichia coli,PASSED
+SAMPLE3,EC004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC004.flat_sample.json.gz,Escherichia coli,FAILED
+SAMPLE4,EC005,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC005.flat_sample.json.gz,Escherichia coli,PASSED
+SAMPLE5,EC006,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC006.flat_sample.json.gz,Escherichia coli,PASSED
+SAMPLE6,EC007,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC007.flat_sample.json.gz,Escherichia coli,PASSED
+SAMPLE7,EC008,,Escherichia coli,PASSED
+SAMPLE8,EA001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EA001.flat_sample.json.gz,Escherichia coli,PASSED

--- a/tests/data/samplesheets/samplesheet_exclusions.csv
+++ b/tests/data/samplesheets/samplesheet_exclusions.csv
@@ -1,6 +1,6 @@
 sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
-SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASS
-SAMPLE2,SALM004,,Salmonella enterica,PASS
-SAMPLE3,SALM005,,Salmonella enterica,FAIL
-SAMPLE4,LIST001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/LIST001.flat_sample.json.gz,Listeria monocytogenes,PASS
-SAMPLE5,CAMP001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/CAMP001.flat_sample.json.gz,Campylobacter_coli,FAIL
+SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella houtenae,PASSED
+SAMPLE2,SALM004,,Salmonella enterica,PASSED
+SAMPLE3,SALM005,,Salmonella enterica,FAILED
+SAMPLE4,LIST001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/LIST001.flat_sample.json.gz,Listeria monocytogenes,PASSED
+SAMPLE5,CAMP001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/CAMP001.flat_sample.json.gz,Campylobacter_coli,FAILED

--- a/tests/data/samplesheets/samplesheet_incorrectJSON.csv
+++ b/tests/data/samplesheets/samplesheet_incorrectJSON.csv
@@ -1,2 +1,2 @@
 sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
-SAMPLE1,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASS
+SAMPLE1,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASSED

--- a/tests/data/samplesheets/samplesheet_sequence.csv
+++ b/tests/data/samplesheets/samplesheet_sequence.csv
@@ -1,7 +1,7 @@
 sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
-SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASS
-SAMPLE2,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM002.flat_sample.json.gz,Salmonella_enterica,FAIL
-SAMPLE4,SALM005,,Salmonella_enterica,PASS
-SAMPLE5,SALM013,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM013.flat_sample.json.gz,Salmonella_enterica,FAIL
-SAMPLE6,CAMP001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/CAMP001.flat_sample.json.gz,Campylobacter coli,FAIL
-SAMPLE7,EC004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC004.flat_sample.json.gz,Escherichia coli,FAIL
+SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASSED
+SAMPLE2,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM002.flat_sample.json.gz,Salmonella_enterica,FAILED
+SAMPLE4,SALM005,,Salmonella_enterica,PASSED
+SAMPLE5,SALM013,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM013.flat_sample.json.gz,Salmonella_enterica,FAILED
+SAMPLE6,CAMP001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/CAMP001.flat_sample.json.gz,Campylobacter coli,FAILED
+SAMPLE7,EC004,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/EC004.flat_sample.json.gz,Escherichia coli,FAILED

--- a/tests/data/samplesheets/samplesheet_sistr.csv
+++ b/tests/data/samplesheets/samplesheet_sistr.csv
@@ -1,11 +1,11 @@
 sample,sample_name,mikrokondo_data,predicted_identification_name,qc_status_overall
-SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASS
-SAMPLE2,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM002.flat_sample.json.gz,Salmonella_enterica,FAIL
-SAMPLE3,SALM005,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM005.flat_sample.json.gz,Salmonella_enterica,PASS
-SAMPLE4,SALM008,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM008.flat_sample.json.gz,Salmonella enterica,PASS
-SAMPLE5,SALM009,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM009.flat_sample.json.gz,Salmonella_enterica,PASS
-SAMPLE6,SALM010,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM010.flat_sample.json.gz,Salmonella enterica,PASS
-SAMPLE7,SALM007,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM007.flat_sample.json.gz,Salmonella_enterica,PASS
-SAMPLE8,SALM011,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM011.flat_sample.json.gz,Salmonella enterica,PASS
-SAMPLE9,SALM012,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM012.flat_sample.json.gz,Salmonella_enterica,PASS
-SAMPLE10,SALM013,,Salmonella enterica,PASS
+SAMPLE1,SALM001,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM001.flat_sample.json.gz,Salmonella_houtenae,PASSED
+SAMPLE2,SALM002,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM002.flat_sample.json.gz,Salmonella_enterica,FAILED
+SAMPLE3,SALM005,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM005.flat_sample.json.gz,Salmonella_enterica,PASSED
+SAMPLE4,SALM008,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM008.flat_sample.json.gz,Salmonella enterica,PASSED
+SAMPLE5,SALM009,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM009.flat_sample.json.gz,Salmonella_enterica,PASSED
+SAMPLE6,SALM010,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM010.flat_sample.json.gz,Salmonella enterica,PASSED
+SAMPLE7,SALM007,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM007.flat_sample.json.gz,Salmonella_enterica,PASSED
+SAMPLE8,SALM011,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM011.flat_sample.json.gz,Salmonella enterica,PASSED
+SAMPLE9,SALM012,https://raw.githubusercontent.com/phac-nml/typingQC/dev/tests/data/SALM012.flat_sample.json.gz,Salmonella_enterica,PASSED
+SAMPLE10,SALM013,,Salmonella enterica,PASSED

--- a/workflows/typingQC.nf
+++ b/workflows/typingQC.nf
@@ -79,13 +79,13 @@ workflow TYPINGQC {
             tuple(meta, mikro_file ? [file(mikro_file)] : [])
         }
         .branch {
-            salmonella_qcFAIL: !it[1].isEmpty() && it[0].QCStatus == 'FAIL' && (it[0].Species ?: "").contains('Salmonella')
-            escherichia_qcFAIL: !it[1].isEmpty() && it[0].QCStatus == 'FAIL' && (it[0].Species ?: "").contains('Escherichia')
+            salmonella_qcFAIL: !it[1].isEmpty() && it[0].QCStatus == 'FAILED' && (it[0].Species ?: "").contains('Salmonella')
+            escherichia_qcFAIL: !it[1].isEmpty() && it[0].QCStatus == 'FAILED' && (it[0].Species ?: "").contains('Escherichia')
 
-            salmonella_PASS: !it[1].isEmpty() && it[0].QCStatus == 'PASS' && (it[0].Species ?: "").contains('Salmonella')
-            escherichia_PASS: !it[1].isEmpty() && it[0].QCStatus == 'PASS' && (it[0].Species ?: "").contains('Escherichia')
+            salmonella_PASS: !it[1].isEmpty() && it[0].QCStatus == 'PASSED' && (it[0].Species ?: "").contains('Salmonella')
+            escherichia_PASS: !it[1].isEmpty() && it[0].QCStatus == 'PASSED' && (it[0].Species ?: "").contains('Escherichia')
 
-            sequence_FAIL: !it[1].isEmpty() && it[0].QCStatus == 'FAIL'
+            sequence_FAIL: !it[1].isEmpty() && it[0].QCStatus == 'FAILED'
 
             fallthrough: true
         }


### PR DESCRIPTION
This PR updates the outputs from `mikrokondo` for the `qc_status_overall` as the tense was incorrect. 
Samplesheets were updated to reflect the change. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
