### PR TITLE
Update/nf test/nextflow v.25.10.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
       matrix:
         NXF_VER:
           - "23.04.0"
+          - "24.10.3"
           - "25.10.4"
-          - "latest-everything"
+          # - "latest-everything"
     steps:
       - name: Check out pipeline code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         NXF_VER:
           - "23.04.0"
-          - "24.10.3"
+          - "25.10.4"
           - "latest-everything"
     steps:
       - name: Check out pipeline code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026/03/20
+
+### `CHANGED`
+- Updated pipeline to include compatibility of nextflow version 25.10.4. [PR 19](https://github.com/phac-nml/typingQC/pull/19)
+- Updated the .github/workflows/ci.yml to run specific versions of nextflow (23.04.0, 24.10.3 and 25.10.4) for nf-test. [PR 19](https://github.com/phac-nml/typingQC/pull/19)
+
 ## [1.0.1] - 2026/02/13
 
 ### `CHANGED`
@@ -23,6 +29,7 @@ Initial release of phac-nml/typingQC, created with the [iridanextexample](https:
 
 ### `Deprecated`
 
+[1.0.2]: https://github.com/phac-nml/typingQC/releases/tag/1.0.2
 [1.0.1]: https://github.com/phac-nml/typingQC/releases/tag/1.0.1
 [1.0.0]: https://github.com/phac-nml/typingQC/releases/tag/1.0.0
 [Overriding container registries with the container directive]: https://github.com/phac-nml/pipeline-standards?tab=readme-ov-file#521-module-software-requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] - 2026/03/20
 
 ### `CHANGED`
+
 - Updated pipeline to include compatibility of nextflow version 25.10.4. [PR 19](https://github.com/phac-nml/typingQC/pull/19)
 - Updated the .github/workflows/ci.yml to run specific versions of nextflow (23.04.0, 24.10.3 and 25.10.4) for nf-test. [PR 19](https://github.com/phac-nml/typingQC/pull/19)
 

--- a/modules/local/exclusions/main.nf
+++ b/modules/local/exclusions/main.nf
@@ -17,7 +17,7 @@ process EXCLUSIONS {
     def args = task.ext.args ?: ''
     def species = meta.Species ?: "Unknown"
     def qc_status = meta.QCStatus ?: "Unknown"
-    def has_file = mikro_file && mikro_file.size() > 0 ? "--has_mikro_file" :  ""
+    def has_file = (mikro_file && mikro_file.name != 'NO_FILE') ? "--has_mikro_file" :  ""
     """
     parse_untypable.py \\
     --sample_id ${meta.id} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@
     Default config options for all compute environments
 ----------------------------------------------------------------------------------------
 */
-
+//
 // Global default params, used in configs
 params {
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -211,7 +211,7 @@ manifest {
     description     = """Genome Typing Quality Control Assessment"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=23.04.0'
-    version         = '1.0.1'
+    version         = '1.0.2'
     doi             = ''
     defaultBranch   = 'main'
 }

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -309,7 +309,7 @@ nextflow_pipeline {
 
         then {
             assert workflow.failed
-            assert workflow.stdout.any { it =~ /ERROR ~ Argument of `file\(\)?` function cannot be empty/ }
+            assert workflow.stdout.any { it =~ /Argument of .* function cannot be empty/ }
         }
     }
 

--- a/tests/pipelines/main.nf.test
+++ b/tests/pipelines/main.nf.test
@@ -309,7 +309,7 @@ nextflow_pipeline {
 
         then {
             assert workflow.failed
-            assert workflow.stdout.contains("ERROR ~ Argument of `file` function cannot be empty")
+            assert workflow.stdout.any { it =~ /ERROR ~ Argument of `file\(\)?` function cannot be empty/ }
         }
     }
 


### PR DESCRIPTION
- Added nextflow 25.10.4 to GHA for nf-test
- Made compatible with versions 23-26 of nextflow: 
    - Modified the EXCLUSIONS process to check for mikrokondo file in channel using an approach that works for all versions of nextflow 
    - Fixed up SISTR empty file test